### PR TITLE
Center blog/article content on wide screens and move author bio

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -358,6 +358,40 @@ button::-moz-focus-inner{padding:0;border:0;}
 .mfp-arrow:after,.mfp-arrow .mfp-a{opacity:0.8;border-top-width:12px;border-bottom-width:12px;top:8px;}
 .mfp-arrow:before,.mfp-arrow .mfp-b{border-top-width:20px;border-bottom-width:20px;}
 .mfp-arrow-left{left:0;-webkit-border-top-right-radius:5px;-webkit-border-bottom-right-radius:5px;-webkit-border-bottom-left-radius:0;-webkit-border-top-left-radius:0;-moz-border-radius-topright:5px;-moz-border-radius-bottomright:5px;-moz-border-radius-bottomleft:0;-moz-border-radius-topleft:0;border-top-right-radius:5px;border-bottom-right-radius:5px;border-bottom-left-radius:0;border-top-left-radius:0;-webkit-background-clip:padding-box;-moz-background-clip:padding;background-clip:padding-box;}
+
+/* Blog readability refresh */
+body.article,
+body.articles{background-color:#f9f9f9;color:#2e2e2e;}
+
+body.article #main,
+body.articles #index{margin-top:2rem;}
+
+body.article #main article,
+body.articles #index{float:none;width:auto;max-width:820px;margin:0 auto 2.5rem;padding:0 1.5rem;}
+
+body.article .headline-wrap{margin-bottom:1.5rem;}
+body.article .headline-wrap h1{font-size:2.4rem;line-height:1.2;margin-bottom:0.5rem;}
+body.article .headline-wrap h2{font-size:1.1rem;line-height:1.4;text-transform:none;color:#666;margin-bottom:0;}
+
+body.article .article-wrap{font-size:1.05rem;line-height:1.85;color:#2e2e2e;}
+body.article .article-wrap p{margin-bottom:1.2rem;text-indent:0;}
+body.article .article-wrap p+p{margin-top:0;}
+body.article .article-wrap ul,
+body.article .article-wrap ol{margin:0 0 1.5rem 1.5rem;}
+body.article .article-wrap li{margin-bottom:0.5rem;}
+body.article .article-wrap blockquote{background:#f1f1f1;border-left:4px solid #c4c4c4;padding:0.75rem 1rem;margin:1.5rem 0;}
+body.article .article-wrap img:not(.floatpic){display:block;margin:1.5rem auto;max-width:100%;height:auto;border-radius:6px;box-shadow:0 4px 16px rgba(0,0,0,0.08);}
+body.article .article-wrap a{border-bottom:1px solid #d0d0d0;}
+body.article .article-wrap a:hover{border-bottom-color:#666;}
+
+body.articles #index article{margin-bottom:1.75rem;padding-bottom:1.5rem;border-bottom:1px solid #e6e6e6;}
+body.articles #index article:last-child{border-bottom:none;padding-bottom:0;margin-bottom:0;}
+body.articles #index h2{line-height:1.3;}
+body.articles #index h3{margin-top:2rem;margin-bottom:0.5rem;}
+body.articles #index p{margin-bottom:0;text-indent:0;}
+
+body.article .article-author-top{display:none;}
+body.article .article-author-bottom{display:block;}
 .mfp-arrow-left:after,.mfp-arrow-left .mfp-a{border-right:12px solid #fff;left:5px;}
 .mfp-arrow-left:before,.mfp-arrow-left .mfp-b{border-right:20px solid #fff;}
 .mfp-arrow-right{right:0;-webkit-border-top-right-radius:0;-webkit-border-bottom-right-radius:0;-webkit-border-bottom-left-radius:5px;-webkit-border-top-left-radius:5px;-moz-border-radius-topright:0;-moz-border-radius-bottomright:0;-moz-border-radius-bottomleft:5px;-moz-border-radius-topleft:5px;border-top-right-radius:0;border-bottom-right-radius:0;border-bottom-left-radius:5px;border-top-left-radius:5px;-webkit-background-clip:padding-box;-moz-background-clip:padding;background-clip:padding-box;}
@@ -406,3 +440,13 @@ img.mfp-img{width:auto;max-width:100%;height:auto;display:block;line-height:0;-w
 .publication-card .pub-summary{margin:0;font-size:0.92rem;line-height:1.5;color:#1c1c1c;}
 @media (max-width:1024px){.publication-card{grid-template-columns:minmax(0,1fr);padding:1.5rem;} .publication-card .pub-body{gap:1rem;} .publication-card .pub-image{max-width:440px;margin:0 auto;} }
 @media (max-width:640px){.publication-card{gap:1.35rem;padding:1.35rem;} .publication-card .pub-title{font-size:1.1rem;} .publication-card .pub-authors,.publication-card .pub-summary{font-size:0.9rem;}}
+
+/* Override layout floats for blog readability on wider screens */
+@media only screen and (min-width:37.5em){
+  body.article #main article,
+  body.articles #index{
+    float:none;
+    width:100%;
+    margin:0 auto 2.5rem;
+  }
+}


### PR DESCRIPTION
### Motivation
- Fix wide-screen layout where article and index columns float side-by-side causing messy alignment and poor readability.
- Ensure author metadata doesn't interrupt the main article flow by preferring the bottom author block on article pages.

### Description
- Added a media-query override that removes floats for `body.article #main article` and `body.articles #index` on wider screens so content is centered and uses full-width stacking instead of side-by-side floats.
- Hid the top author block by adding `body.article .article-author-top{display:none;}` and enabled the bottom author block with `body.article .article-author-bottom{display:block;}`.
- Included the new readability CSS rules in `assets/css/main.css` scoped under a "Blog readability refresh" section to keep typography and spacing consistent for articles and the index.

### Testing
- Inspected the updated `assets/css/main.css` with `nl -ba assets/css/main.css | sed -n '360,460p'` to confirm the inserted rules are present.
- No site build or unit tests were executed because the site generator (`jekyll`) is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697771358d9c8323bc1589da247c19d0)