### PR TITLE
Separate Startup (HIVE) and Vibe Products into distinct pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,8 +45,10 @@ links:
     url: /
   - title: Publications
     url: /publications/
-  - title: startup
+  - title: Startup
     url: /teams/
+  - title: Vibe Products
+    url: /products/
  # - title: Hobbies
  #   url: /hobbies/
   - title: Awards

--- a/products.md
+++ b/products.md
@@ -1,0 +1,48 @@
+---
+layout: page
+permalink: /products/index.html
+title: Vibe Products
+---
+## 思网 IdeaMesh
+
+### Motivation
+
+We believe AI can never truly replace human thought and expression—after all, human wisdom is boundless. That’s why we built a multi-perspective, inspiration-driven content platform. In this era of digital overload and algorithmic feeds, we want to preserve genuine curiosity and fragile authenticity. Our goal? To keep interesting, unique, and diverse perspectives from being reduced to clichés or templates.<br>
+
+---
+
+### Team Members
+
+- **Co-founders:** Jiacheng Jiang, Leo Wang, Tao Lin
+
+---
+
+### About Us
+
+> Our group website: [Web端官网](https://idea-mesh.vercel.app/)
+
+> Our repo: [Github仓库(欢迎star)](https://github.com/leowio/idea-mesh)
+
+> Our Platform Guidelines: [平台指南](https://q8aq2rpyhu.feishu.cn/wiki/Ftt6wWTNGiFrzikP6B7ckev2nYf)
+
+## WeShare
+
+### Motivation
+
+We strive to create a comprehensive competition exchange platform that breaks down information barriers through sharing experiences and solutions, helping participants resolve confusion and improve their chances of winning.<br>
+
+---
+
+### Team Members
+
+- **Co-founders:** Tao Lin, [Qiwei Liang](https://kolakivy.github.io/), Yihao Hu
+- **Members @2025:** Zishuo Zhang, Hanmo Chen, Pan Wang, Ming Luo, Qiahao Huang
+
+---
+
+### About Us
+
+> Our group website: [WeShare官网](https://weshare.xin/)
+
+> Our logo:
+![WeShare团队Logo](https://lintao.online/images/teams/cover1.jpg)

--- a/teams.md
+++ b/teams.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 permalink: /teams/index.html
-title: Teams
+title: Startup
 ---
 ## HIVE GROUP
 
@@ -22,84 +22,3 @@ We’re a community of curious builders exploring the future of embodied intelli
 > Our group website: [网站](https://hive-robot.github.io/)
 
 > The team is currently in an early exploratory phase, with all research and development carried out independently by its members. We welcome all forms of collaboration, including research partnerships, resource sharing, technical discussions, and mentorship, as we work together to advance the field of embodied intelligence.😊
-
-## 思网IdeaMesh
-
-### Motivation
-
-We believe AI can never truly replace human thought and expression—after all, human wisdom is boundless. That’s why we built a multi-perspective, inspiration-driven content platform. In this era of digital overload and algorithmic feeds, we want to preserve genuine curiosity and fragile authenticity. Our goal? To keep interesting, unique, and diverse perspectives from being reduced to clichés or templates.<br>
-
----
-
-### Team Members
-
-- **Co-founders:** Jiacheng Jiang, Leo Wang, Tao Lin
-
----
-
-### About Us
-
-> Our group website: [Web端官网](https://idea-mesh.vercel.app/)
-
-> Our repo: [Github仓库(欢迎star)](https://github.com/leowio/idea-mesh)
-
-> Our Platform Guidelines: [平台指南](https://q8aq2rpyhu.feishu.cn/wiki/Ftt6wWTNGiFrzikP6B7ckev2nYf)
-
-## WeShare
-
-### Motivation
-
-We strive to create a comprehensive competition exchange platform that breaks down information barriers through sharing experiences and solutions, helping participants resolve confusion and improve their chances of winning.<br>
-
----
-
-### Team Members
-
-- **Co-founders:** Tao Lin, [Qiwei Liang](https://kolakivy.github.io/), Yihao Hu
-- **Members @2025:** Zishuo Zhang, Hanmo Chen, Pan Wang, Ming Luo, Qiahao Huang
-
----
-
-### About Us
-
-> Our group website: [WeShare官网](https://weshare.xin/)
-
-> Our logo:
-![WeShare团队Logo](https://lintao.online/images/teams/cover1.jpg)
-
-<!--
-<div>
-    <img src="https://caihanlin.com/images/teams/teams1.jpg">
-</div>
-<br>
-
-<div>
-    <img src="https://caihanlin.com/images/teams/teams2.jpg">
-</div>
-<br>
-
-<div>
-    <img src="https://caihanlin.com/images/teams/teams.jpg">
-</div>
-<br>
-
-<div>
-    <img src="https://caihanlin.com/images/teams/teams4.jpg">
-</div>
-<br>
-
-## WeShare Team
-
-During my undergraduate years, together with Qiwei Liang and Yihao Hu, I co-founded a group named WeShare. Initially, we took the initiative in establishing the group. Driven by an entrepreneurial spirit in technology, we actively invited more individuals to join our team. As of now, the WeShare team has expanded to include 8 official members.<br>
-
-## Team News
-
-- **April 2025**: If you're interested in sharing experiences and knowledge about various competitions, welcome to [join us!](https://weshare.xin/)<br>
-
----
-
-## Our Fundings
-
-- We are currently looking for the right funding to help this project reach its full potential. If you are an investor and are passionate about this project that can change the college competition community, we would love to discuss ways to work with you. With your support, we can grow this project into a larger and more influential platform.<br><br>
-
--->


### PR DESCRIPTION
### Motivation
- Separate a single mixed “startup” page into a dedicated Startup (HIVE group) page and a distinct Vibe Products page to improve site information architecture and clarity.

### Description
- Updated top navigation in `_config.yml` by renaming `startup` to `Startup` and adding a new `Vibe Products` entry that links to `/products/`.
- Simplified `teams.md` so it becomes a dedicated Startup page (HIVE GROUP only) and adjusted its `title` and `permalink` accordingly.
- Added a new `products.md` with `permalink: /products/index.html` and `title: Vibe Products`, moving the IdeaMesh and WeShare sections there.

### Testing
- Reviewed the change set with `git diff -- teams.md products.md _config.yml` and inspected file contents with `nl -ba`, confirming content was moved as intended.
- Verified repository status with `git status --short` to ensure the working tree reflected the edits.
- Attempted a local build with `bundle exec jekyll build`, which failed because the current environment lacks a `Gemfile` / `.bundle` for a full Jekyll build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbd93d35a48323bfc613213fad3aba)